### PR TITLE
Add AI-powered watchlist queries (backend + docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ Search results display key movie metadata and allow users to add titles directly
 - **Authentication**
    - bcrypt, JWT (stored in an httpOnly cookie)
 - **External API**
-   - [OMDb API](https://www.omdbapi.com/)
+   - [OMDb API](https://www.omdbapi.com/) (movie data)
+   - OpenAI API (natural language watchlist queries)
 - **Deployment**
    - Vercel (frontend)
    - Render (backend)
@@ -78,6 +79,7 @@ Search results display key movie metadata and allow users to add titles directly
 - The **React + Vite frontend** communicates with an **Express REST API**
 - The API handles **authentication, search requests, and watchlist management**
 - Search requests are proxied to the **OMDb API**, and the server fetches full metadata for each result
+- Natural language watchlist queries are parsed using the **OpenAI API** and converted into structured database filters
 - **Prisma ORM** manages database access for user accounts and watchlists
 - Watchlist data is stored in **PostgreSQL (Neon)**
 - Authentication is implemented with **JWT tokens stored in secure httpOnly cookies**
@@ -103,16 +105,23 @@ reelsearch/
 │
 ├─ server/                  # Express backend (API, auth, watchlist features)
 │  ├─ index.js              # Express entry point
+│  ├─ db.js                 # Prisma client initialization
+│  ├─ lib/
+│  │  └─ openai.js          # OpenAI client setup
 │  ├─ routes/
 │  │  ├─ auth.routes.js
+│  │  ├─ chat.routes.js     # Natural language watchlist queries
 │  │  ├─ search.routes.js
 │  │  └─ watchlist.routes.js
 │  ├─ services/
-│  │  └─ omdb.service.js    # OMDb API proxy logic
+│  │  ├─ omdb.service.js    # OMDb API proxy logic
+│  │  ├─ chat.service.js
+│  │  └─ watchlistQuery.service.js
 │  ├─ middleware/
 │  │  └─ requireAuth.js     # JWT cookie authentication middleware
 │  └─ utils/
-│     └─ ratings.util.js    # Rating normalization helpers
+│     └─ ratings.util.js
+│     └─ serializeWatchlistItem.util.js
 │
 ├─ prisma/
 │  ├─ schema.prisma         # Prisma schema defining User & Watchlist models
@@ -168,6 +177,7 @@ Normalize critic ratings to enable future ranking and sorting features.
 - npm (bundled with Node.js)
 - A PostgreSQL database URL (e.g. via [Neon](https://neon.com/), [Supabase](https://supabase.com/), local PostgreSQL)
 - An OMDb API key (free: https://www.omdbapi.com/apikey.aspx)
+- An OpenAI API key (https://platform.openai.com/)
 
 ### Installation and Setup
 1. **Fork or Clone the Repository**
@@ -199,7 +209,10 @@ Normalize critic ratings to enable future ranking and sorting features.
    JWT_SECRET="a-long-random-string-here"
 
    # OMDb API key (used only on the backend)
-   API_KEY="your_omdb_api_key_here"
+   OMDB_API_KEY="your_omdb_api_key_here"
+
+   # OpenAI API key (used for chat-based watchlist queries)
+   OPENAI_API_KEY="your_openai_api_key_here"
 
    # Optional: port for the Express API (default is 5000)
    PORT=5000
@@ -279,6 +292,19 @@ Once `npm run dev` is running:
    - Stores the item for the current user
 - `DELETE /api/watchlist/:imdbId`
    - Removes specific item from the user’s watchlist
+
+### Chat ( /api/chat )
+**Note:** Requires authentication (`requireAuth` middleware)
+- `POST /api/chat/watchlist`  
+   Body: `{ "message": string }`  
+   - Parses natural language input using OpenAI  
+   - Converts the request into structured filters and sorting options  
+   - Returns filtered/sorted watchlist items  
+
+   Example:
+   ```json
+   { "message": "show my sci-fi movies after 2015" }
+   ```
 
 <br>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "cors": "^2.8.5",
         "dotenv": "^17.3.1",
         "express": "^5.1.0",
-        "jsonwebtoken": "^9.0.2"
+        "jsonwebtoken": "^9.0.2",
+        "openai": "^6.34.0"
       },
       "devDependencies": {
         "concurrently": "^9.2.0",
@@ -47,37 +48,37 @@
       }
     },
     "node_modules/@prisma/config": {
-      "version": "6.19.2",
-      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.19.2.tgz",
-      "integrity": "sha512-kadBGDl+aUswv/zZMk9Mx0C8UZs1kjao8H9/JpI4Wh4SHZaM7zkTwiKn/iFLfRg+XtOAo/Z/c6pAYhijKl0nzQ==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.19.3.tgz",
+      "integrity": "sha512-CBPT44BjlQxEt8kiMEauji2WHTDoVBOKl7UlewXmUgBPnr/oPRZC3psci5chJnYmH0ivEIog2OU9PGWoki3DLQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "c12": "3.1.0",
         "deepmerge-ts": "7.1.5",
-        "effect": "3.18.4",
+        "effect": "3.21.0",
         "empathic": "2.0.0"
       }
     },
     "node_modules/@prisma/debug": {
-      "version": "6.19.2",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.19.2.tgz",
-      "integrity": "sha512-lFnEZsLdFLmEVCVNdskLDCL8Uup41GDfU0LUfquw+ercJC8ODTuL0WNKgOKmYxCJVvFwf0OuZBzW99DuWmoH2A==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.19.3.tgz",
+      "integrity": "sha512-ljkJ+SgpXNktLG0Q/n4JGYCkKf0f8oYLyjImS2I8e2q2WCfdRRtWER062ZV/ixaNP2M2VKlWXVJiGzZaUgbKZw==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
-      "version": "6.19.2",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.19.2.tgz",
-      "integrity": "sha512-TTkJ8r+uk/uqczX40wb+ODG0E0icVsMgwCTyTHXehaEfb0uo80M9g1aW1tEJrxmFHeOZFXdI2sTA1j1AgcHi4A==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.19.3.tgz",
+      "integrity": "sha512-RSYxtlYFl5pJ8ZePgMv0lZ9IzVCOdTPOegrs2qcbAEFrBI1G33h6wyC9kjQvo0DnYEhEVY0X4LsuFHXLKQk88g==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.19.2",
+        "@prisma/debug": "6.19.3",
         "@prisma/engines-version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
-        "@prisma/fetch-engine": "6.19.2",
-        "@prisma/get-platform": "6.19.2"
+        "@prisma/fetch-engine": "6.19.3",
+        "@prisma/get-platform": "6.19.3"
       }
     },
     "node_modules/@prisma/engines-version": {
@@ -88,25 +89,25 @@
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "6.19.2",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.19.2.tgz",
-      "integrity": "sha512-h4Ff4Pho+SR1S8XerMCC12X//oY2bG3Iug/fUnudfcXEUnIeRiBdXHFdGlGOgQ3HqKgosTEhkZMvGM9tWtYC+Q==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.19.3.tgz",
+      "integrity": "sha512-tKtl/qco9Nt7LU5iKhpultD8O4vMCZcU2CHjNTnRrL1QvSUr5W/GcyFPjNL87GtRrwBc7ubXXD9xy4EvLvt8JA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.19.2",
+        "@prisma/debug": "6.19.3",
         "@prisma/engines-version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
-        "@prisma/get-platform": "6.19.2"
+        "@prisma/get-platform": "6.19.3"
       }
     },
     "node_modules/@prisma/get-platform": {
-      "version": "6.19.2",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.19.2.tgz",
-      "integrity": "sha512-PGLr06JUSTqIvztJtAzIxOwtWKtJm5WwOG6xpsgD37Rc84FpfUBGLKz65YpJBGtkRQGXTYEFie7pYALocC3MtA==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.19.3.tgz",
+      "integrity": "sha512-xFj1VcJ1N3MKooOQAGO0W5tsd0W2QzIvW7DD7c/8H14Zmp4jseeWAITm+w2LLoLrlhoHdPPh0NMZ8mfL6puoHA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.19.2"
+        "@prisma/debug": "6.19.3"
       }
     },
     "node_modules/@standard-schema/spec": {
@@ -609,9 +610,9 @@
       }
     },
     "node_modules/defu": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -673,9 +674,9 @@
       "license": "MIT"
     },
     "node_modules/effect": {
-      "version": "3.18.4",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-3.18.4.tgz",
-      "integrity": "sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.21.0.tgz",
+      "integrity": "sha512-PPN80qRokCd1f015IANNhrwOnLO7GrrMQfk4/lnZRE/8j7UPWrNNjPV0uBrZutI/nHzernbW+J0hdqQysHiSnQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -1455,9 +1456,9 @@
       }
     },
     "node_modules/nypm/node_modules/citty": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.1.tgz",
-      "integrity": "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
+      "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -1508,6 +1509,27 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.34.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.34.0.tgz",
+      "integrity": "sha512-yEr2jdGf4tVFYG6ohmr3pF6VJuveP0EA/sS8TBx+4Eq5NT10alu5zg2dmxMXMgqpihRDQlFGpRt2XwsGj+Fyxw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/parseurl": {
@@ -1569,15 +1591,15 @@
       }
     },
     "node_modules/prisma": {
-      "version": "6.19.2",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.19.2.tgz",
-      "integrity": "sha512-XTKeKxtQElcq3U9/jHyxSPgiRgeYDKxWTPOf6NkXA0dNj5j40MfEsZkMbyNpwDWCUv7YBFUl7I2VK/6ALbmhEg==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.19.3.tgz",
+      "integrity": "sha512-++ZJ0ijLrDJF6hNB4t4uxg2br3fC4H9Yc9tcbjr2fcNFP3rh/SBNrAgjhsqBU4Ght8JPrVofG/ZkXfnSfnYsFg==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/config": "6.19.2",
-        "@prisma/engines": "6.19.2"
+        "@prisma/config": "6.19.3",
+        "@prisma/engines": "6.19.3"
       },
       "bin": {
         "prisma": "build/index.js"
@@ -1971,9 +1993,9 @@
       }
     },
     "node_modules/tinyexec": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
-      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
       "devOptional": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "cors": "^2.8.5",
     "dotenv": "^17.3.1",
     "express": "^5.1.0",
-    "jsonwebtoken": "^9.0.2"
+    "jsonwebtoken": "^9.0.2",
+    "openai": "^6.34.0"
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,42 +24,44 @@ model User {
 model WatchlistItem {
   userId          Int
   imdbId          String
+
+  // Core metadata
   title           String
-  poster          String?
-
-  year            String    // raw OMDb year text, e.g. "2016", "2019–2022"
-  releaseYear     Int?      // parsed first year for sorting/filtering
-
   type            String
+  poster          String?
   rated           String?
 
+  // Raw OMDb fields
+  year            String?   // raw OMDb year text, e.g. "2016", "2019–2022"
   genre           String?   // raw OMDb genre text
-  genres          String[]  // parsed array
+  runtime         String?   // e.g. "148 min"
+  language        String?   // raw OMDb language text
+  boxOffice       String?   // e.g. "$858,373,000"
 
+  // Parsed / query fields
+  releaseYear     Int?      // parsed first year for sorting/filtering
+  genres          String[]  // parsed array
+  runtimeMins     Int?
+  languages       String[]  // parsed array
+  boxOfficeValue  BigInt?   // parsed integer dollars
+
+  // Descriptive metadata
   plot            String?
   director        String?
   actors          String?
 
-  runtime         String?   // e.g. "148 min"
-  runtimeMins     Int?
-
-  language        String?   // raw OMDb language text
-  languages       String[]  // parsed array
-
-  boxOffice       String?   // e.g. "$858,373,000"
-  boxOfficeValue  BigInt?   // parsed integer dollars
-
+  // Raw ratings
   imdbRaw         String?   // e.g. "8.7/10"
   rtRaw           String?   // e.g. "95%"
   mcRaw           String?   // e.g. "82/100"
 
+  // Normalized ratings
   imdbScore       Float?
   rtScore         Int?      
   mcScore         Int?
   sortScore       Float?    // Average of the 3 available scores
 
   createdAt       DateTime @default(now())
-
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@id([userId, imdbId])

--- a/server/index.js
+++ b/server/index.js
@@ -3,6 +3,7 @@ import express from 'express';
 import cookieParser from 'cookie-parser';
 import cors from 'cors';
 import authRoutes from './routes/auth.routes.js';
+import chatRoutes from './routes/chat.routes.js';
 import searchRoutes from './routes/search.routes.js';
 import watchlistRoutes from './routes/watchlist.routes.js';
 
@@ -23,6 +24,7 @@ app.use(cookieParser());
 // Routes
 app.get('/health', (_req, res) => res.json({ ok: true }));
 app.use('/api/auth', authRoutes);
+app.use('/api/chat', chatRoutes);
 app.use('/api/search', searchRoutes);
 app.use('/api/watchlist', watchlistRoutes);
 

--- a/server/lib/openai.js
+++ b/server/lib/openai.js
@@ -1,0 +1,5 @@
+import OpenAI from 'openai';
+
+export const openai = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY,
+});

--- a/server/routes/chat.routes.js
+++ b/server/routes/chat.routes.js
@@ -1,0 +1,68 @@
+import { Router } from 'express';
+import { prisma } from '../db.js';
+import { requireAuth } from '../middleware/requireAuth.js';
+import { parseWatchlistMessage } from '../services/chat.service.js';
+import { buildWatchlistQuery } from '../services/watchlistQuery.service.js';
+import { serializeWatchlistItem } from '../utils/serializeWatchlistItem.util.js';
+
+const router = Router();
+
+router.post('/watchlist', requireAuth, async (req, res) => {
+  try {
+    const { message } = req.body ?? {};
+
+    if (typeof message !== 'string' || message.trim() === '') {
+      return res.status(400).json({ message: 'message is required' });
+    }
+
+    const action = await parseWatchlistMessage(message.trim());
+
+    const normalizedGenre =
+      typeof action.genre === 'string' && action.genre.trim() !== ''
+        ? action.genre.trim().toLowerCase()
+        : null;
+
+    let filters = {};
+
+    if (action.intent === 'clear_filters') {
+      filters = {};
+    } else if (action.intent === 'sort_watchlist') {
+      filters = {
+        sortBy: action.sortBy ?? null,
+        order: action.order ?? null,
+      };
+    } else if (action.intent === 'filter_watchlist') {
+      filters = {
+        type: action.type ?? null,
+        genre: normalizedGenre,
+        yearGte: action.yearGte ?? null,
+        yearLte: action.yearLte ?? null,
+        runtimeLte: action.runtimeLte ?? null,
+        sortBy: action.sortBy ?? null,
+        order: action.order ?? null,
+      };
+    } else {
+      return res.status(400).json({ message: 'Unsupported chat intent' });
+    }
+
+    const { where, orderBy } = buildWatchlistQuery({
+      userId: req.userId,
+      filters,
+    });
+
+    const items = await prisma.watchlistItem.findMany({
+      where,
+      orderBy,
+    });
+
+    return res.json({
+      action,
+      items: items.map(serializeWatchlistItem),
+    });
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ message: 'Failed to process watchlist chat' });
+  }
+});
+
+export default router;

--- a/server/routes/watchlist.routes.js
+++ b/server/routes/watchlist.routes.js
@@ -3,17 +3,10 @@ import { prisma } from '../db.js';
 import { requireAuth } from '../middleware/requireAuth.js';
 import { getMovieDetails } from '../services/omdb.service.js';
 import { buildWatchlistQuery } from '../services/watchlistQuery.service.js';
+import { serializeWatchlistItem } from '../utils/serializeWatchlistItem.util.js';
 import { normalizeRatings } from '../utils/ratings.util.js';
 
 const router = Router();
-
-function serializeWatchlistItem(item) {
-  return {
-    ...item,
-    boxOfficeValue:
-      item.boxOfficeValue != null ? item.boxOfficeValue.toString() : null,
-  };
-}
 
 // GET user watchlist
 router.get('/', requireAuth, async (req, res) => {
@@ -245,34 +238,32 @@ router.post('/', requireAuth, async (req, res) => {
     const data = {
       userId: req.userId,
       imdbId,
+
       title: movie.Title,
-      poster,
-
-      year,
-      releaseYear,
-
       type,
+      poster,
       rated,
 
+      year,
       genre,
+      runtime,
+      language,
+      boxOffice,
+
+      releaseYear,
       genres,
+      runtimeMins,
+      languages,
+      boxOfficeValue,
 
       plot,
       director,
       actors,
 
-      runtime,
-      runtimeMins,
-
-      language,
-      languages,
-
-      boxOffice,
-      boxOfficeValue,
-
       imdbRaw,
       rtRaw,
       mcRaw,
+
       imdbScore,
       rtScore,
       mcScore,

--- a/server/routes/watchlist.routes.js
+++ b/server/routes/watchlist.routes.js
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { prisma } from '../db.js';
 import { requireAuth } from '../middleware/requireAuth.js';
 import { getMovieDetails } from '../services/omdb.service.js';
+import { buildWatchlistQuery } from '../services/watchlistQuery.service.js';
 import { normalizeRatings } from '../utils/ratings.util.js';
 
 const router = Router();
@@ -19,32 +20,25 @@ router.get('/', requireAuth, async (req, res) => {
   try {
     const { type, genre, sortBy, order, yearGte, yearLte, runtimeLte, } = req.query;
 
-    const where = {
-      userId: req.userId,
-    };
-
-    // Optional type filter
+    // --- Normalize values ---
+    let normalizedType = null;    // Optional type filter
     if (typeof type === 'string' && type.trim() !== '') {
-      const normalizedType = type.trim().toLowerCase();
+      normalizedType = type.trim().toLowerCase();
 
       const allowedTypes = new Set(['movie', 'series', 'game']);
       if (!allowedTypes.has(normalizedType)) {
         return res.status(400).json({ message: 'Invalid type filter' });
       }
-
-      where.type = normalizedType;
     }
 
-    // Optional genre filter
+    let normalizedGenre = null;   // Optional genre filter
     if (typeof genre === 'string' && genre.trim() !== '') {
-      const normalizedGenre = genre.trim().toLowerCase();
-      where.genres = {
-        has: normalizedGenre,
-      };
+      normalizedGenre = genre.trim().toLowerCase();
     }
 
     // Optional year > or < filter
     const currentYear = new Date().getFullYear();
+
     const parsedYearGte =
       typeof yearGte === 'string' && yearGte.trim() !== ''
         ? Number(yearGte)
@@ -75,11 +69,7 @@ router.get('/', requireAuth, async (req, res) => {
       }
     }
 
-    if (
-      parsedYearGte !== null &&
-      parsedYearLte !== null &&
-      parsedYearGte > parsedYearLte
-    ) {
+    if (parsedYearGte !== null && parsedYearLte !== null && parsedYearGte > parsedYearLte) {
       return res.status(400).json({ message: 'yearGte cannot be greater than yearLte' });
     }
 
@@ -97,24 +87,6 @@ router.get('/', requireAuth, async (req, res) => {
       if (parsedRuntimeLte <= 0) {
         return res.status(400).json({ message: 'runtimeLte must be greater than 0' });
       }
-    }
-
-    if (parsedYearGte !== null || parsedYearLte !== null) {
-      where.releaseYear = {};
-
-      if (parsedYearGte !== null) {
-        where.releaseYear.gte = parsedYearGte;
-      }
-
-      if (parsedYearLte !== null) {
-        where.releaseYear.lte = parsedYearLte;
-      }
-    }
-
-    if (parsedRuntimeLte !== null) {
-      where.runtimeMins = {
-        lte: parsedRuntimeLte,
-      };
     }
 
     // Allowed sort fields
@@ -149,9 +121,24 @@ router.get('/', requireAuth, async (req, res) => {
         ? 'desc'
         : 'asc';
 
+    // Call watchlist service to build Prisma *where* and *orderBy*
+    const { where, orderBy } = buildWatchlistQuery({
+      userId: req.userId,
+      filters: {
+        type: normalizedType,
+        genre: normalizedGenre,
+        sortBy: sortField,
+        order: sortOrder,
+        yearGte: parsedYearGte,
+        yearLte: parsedYearLte,
+        runtimeLte: parsedRuntimeLte,
+      },
+    });
+    
+    // Query database
     const items = await prisma.watchlistItem.findMany({
       where,
-      orderBy: { [sortField]: sortOrder },
+      orderBy,
     });
 
     res.json(

--- a/server/services/chat.service.js
+++ b/server/services/chat.service.js
@@ -1,0 +1,117 @@
+import { openai } from '../lib/openai.js';
+
+const watchlistActionSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    intent: {
+      type: 'string',
+      enum: ['filter_watchlist', 'sort_watchlist'],
+    },
+    type: {
+      type: ['string', 'null'],
+      enum: ['movie', 'series', 'game', null],
+    },
+    genre: {
+      type: ['string', 'null'],
+    },
+    yearGte: {
+      type: ['integer', 'null'],
+    },
+    yearLte: {
+      type: ['integer', 'null'],
+    },
+    runtimeLte: {
+      type: ['integer', 'null'],
+    },
+    sortBy: {
+      type: ['string', 'null'],
+      enum: [
+        'createdAt',
+        'title',
+        'releaseYear',
+        'runtimeMins',
+        'imdbScore',
+        'rtScore',
+        'mcScore',
+        'sortScore',
+        null,
+      ],
+    },
+    order: {
+      type: ['string', 'null'],
+      enum: ['asc', 'desc', null],
+    },
+  },
+  required: [
+    'intent',
+    'type',
+    'genre',
+    'yearGte',
+    'yearLte',
+    'runtimeLte',
+    'sortBy',
+    'order',
+  ],
+};
+
+export async function parseWatchlistMessage(message) {
+  const response = await openai.responses.create({
+    model: 'gpt-5.4-mini',
+    input: [
+      {
+        role: 'developer',
+        content: [
+          {
+            type: 'input_text',
+            text:
+              'You convert watchlist chat requests into structured actions. ' +
+              'Only use the supported intents and fields. Do not invent fields. ' +
+
+              'Return one of two intents: "filter_watchlist" or "sort_watchlist". ' +
+
+              'Use "filter_watchlist" when the user asks to filter, narrow, or view items. ' +
+              'Use "sort_watchlist" when the user only asks to change sorting. ' +
+
+              'For type filtering: ' +
+              '- "movie" or "movies" -> type = "movie". ' +
+              '- "show", "shows", "series", or "tv show" -> type = "series". ' +
+              '- "game" or "games" -> type = "game". ' +
+              '- If the user says "show" as a verb (e.g. "show me ...") or does not specify a type, set type to null. ' +
+              '- If the user says "items", "everything", or "all", set type to null. ' +
+
+              'For genre: return a single lowercase genre string if clearly specified (e.g. "sci-fi", "action"), otherwise null. ' +
+
+              'For year and runtime: extract numeric values when present, otherwise null. ' +
+
+              'For sorting: map user intent to supported fields (imdbScore, rtScore, mcScore, sortScore, createdAt, title, releaseYear, runtimeMins). ' +
+              '- imdbScore = IMDb rating. ' +
+              '- rtScore = Rotten Tomatoes score. ' +
+              '- mcScore = Metacritic score. ' +
+              '- sortScore = combined average critic score across sources. ' +
+              '- If the user asks for "best", "top", or "highest rated" without specifying a source, use sortScore. ' +
+              'Use "desc" by default for scores and dates unless the user specifies otherwise. ' +
+
+              'If the user asks to "clear filters", "show all items", or "show everything", return intent "filter_watchlist" with all filter fields set to null. ' +
+
+              'If a field is not explicitly requested, set it to null.',
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: [{ type: 'input_text', text: message }],
+      },
+    ],
+    text: {
+      format: {
+        type: 'json_schema',
+        name: 'watchlist_action',
+        strict: true,
+        schema: watchlistActionSchema,
+      },
+    },
+  });
+
+  return JSON.parse(response.output_text);
+}

--- a/server/services/omdb.service.js
+++ b/server/services/omdb.service.js
@@ -1,10 +1,10 @@
-const API_KEY = process.env.API_KEY;
+const OMDB_API_KEY = process.env.OMDB_API_KEY;
 const BASE_URL = "https://www.omdbapi.com/";
 
 async function fetchOmdb(params) {
   const url = new URL(BASE_URL);
 
-  url.searchParams.set("apikey", API_KEY);
+  url.searchParams.set("apikey", OMDB_API_KEY);
 
   for (const [key, value] of Object.entries(params)) {
     url.searchParams.set(key, value);

--- a/server/services/watchlistQuery.service.js
+++ b/server/services/watchlistQuery.service.js
@@ -1,0 +1,62 @@
+export function buildWatchlistQuery({ userId, filters }) {
+    const {
+        type,
+        genre,
+        sortBy,
+        order,
+        yearGte,
+        yearLte,
+        runtimeLte,
+    } = filters;
+
+    const where = { userId };
+
+    // --- Filtering ---
+    if (type) where.type = type;    // type
+
+    if (genre) where.genres = { has: genre };   // genre
+
+    if (yearGte != null || yearLte != null) {   // year
+        where.releaseYear = {};
+
+        if (yearGte != null) where.releaseYear.gte = yearGte;
+        if (yearLte != null) where.releaseYear.lte = yearLte;
+    }
+
+    if (runtimeLte != null) where.runtimeMins = { lte: runtimeLte };    // runtime
+
+    // --- Sorting ---
+    const allowedSortFields = new Set([
+        'createdAt',
+        'title',
+        'releaseYear',
+        'runtimeMins',
+        'imdbScore',
+        'rtScore',
+        'mcScore',
+        'sortScore',
+    ]);
+
+    const sortField = allowedSortFields.has(sortBy)
+        ? sortBy
+        : 'createdAt';
+
+    const defaultDescFields = new Set([
+        'imdbScore',
+        'rtScore',
+        'mcScore',
+        'sortScore',
+        'createdAt',
+    ]);
+
+    const sortOrder =
+        order === 'desc' || order === 'asc'
+            ? order
+            : defaultDescFields.has(sortField)
+            ? 'desc'
+            : 'asc';
+
+    const orderBy = { [sortField]: sortOrder };
+
+    return { where, orderBy };
+}

--- a/server/services/watchlistQuery.service.js
+++ b/server/services/watchlistQuery.service.js
@@ -1,62 +1,62 @@
 export function buildWatchlistQuery({ userId, filters }) {
-    const {
-        type,
-        genre,
-        sortBy,
-        order,
-        yearGte,
-        yearLte,
-        runtimeLte,
-    } = filters;
+	const {
+		type,
+		genre,
+		sortBy,
+		order,
+		yearGte,
+		yearLte,
+		runtimeLte,
+	} = filters;
 
-    const where = { userId };
+	const where = { userId };
 
-    // --- Filtering ---
-    if (type) where.type = type;    // type
+	// --- Filtering ---
+	if (type) where.type = type;    // type
 
-    if (genre) where.genres = { has: genre };   // genre
+	if (genre) where.genres = { has: genre };   // genre
 
-    if (yearGte != null || yearLte != null) {   // year
-        where.releaseYear = {};
+	if (yearGte != null || yearLte != null) {   // year
+		where.releaseYear = {};
 
-        if (yearGte != null) where.releaseYear.gte = yearGte;
-        if (yearLte != null) where.releaseYear.lte = yearLte;
-    }
+		if (yearGte != null) where.releaseYear.gte = yearGte;
+		if (yearLte != null) where.releaseYear.lte = yearLte;
+	}
 
-    if (runtimeLte != null) where.runtimeMins = { lte: runtimeLte };    // runtime
+	if (runtimeLte != null) where.runtimeMins = { lte: runtimeLte };    // runtime
 
-    // --- Sorting ---
-    const allowedSortFields = new Set([
-        'createdAt',
-        'title',
-        'releaseYear',
-        'runtimeMins',
-        'imdbScore',
-        'rtScore',
-        'mcScore',
-        'sortScore',
-    ]);
+	// --- Sorting ---
+	const allowedSortFields = new Set([
+		'createdAt',
+		'title',
+		'releaseYear',
+		'runtimeMins',
+		'imdbScore',
+		'rtScore',
+		'mcScore',
+		'sortScore',
+	]);
 
-    const sortField = allowedSortFields.has(sortBy)
-        ? sortBy
-        : 'createdAt';
+	const sortField = allowedSortFields.has(sortBy)
+		? sortBy
+		: 'createdAt';
 
-    const defaultDescFields = new Set([
-        'imdbScore',
-        'rtScore',
-        'mcScore',
-        'sortScore',
-        'createdAt',
-    ]);
+	const defaultDescFields = new Set([
+		'imdbScore',
+		'rtScore',
+		'mcScore',
+		'sortScore',
+		'createdAt',
+	]);
 
-    const sortOrder =
-        order === 'desc' || order === 'asc'
-            ? order
-            : defaultDescFields.has(sortField)
-            ? 'desc'
-            : 'asc';
+	const sortOrder =
+		order === 'desc' || order === 'asc'
+			? order
+			: defaultDescFields.has(sortField)
+			? 'desc'
+			: 'asc';
 
-    const orderBy = { [sortField]: sortOrder };
+	const orderBy = { [sortField]: sortOrder };
 
-    return { where, orderBy };
+	return { where, orderBy };
 }

--- a/server/utils/serializeWatchlistItem.util.js
+++ b/server/utils/serializeWatchlistItem.util.js
@@ -1,0 +1,7 @@
+export function serializeWatchlistItem(item) {
+  return {
+    ...item,
+    boxOfficeValue:
+      item.boxOfficeValue != null ? item.boxOfficeValue.toString() : null,
+  };
+}


### PR DESCRIPTION
## Summary
Adds natural language watchlist querying using the OpenAI API. Users can now filter and sort their watchlist using plain English via a new backend endpoint.

## Changes
- Integrate OpenAI structured outputs for parsing user input
- Add `chat.service` for intent and filter extraction
- Add `POST /api/chat/watchlist` endpoint
- Reuse `watchlistQuery.service` for filtering and sorting logic
- Extract `serializeWatchlistItem` into utils for shared response formatting

## Schema Updates
- Make `year` nullable (`String?`)
- Reorganize `WatchlistItem` fields for clarity and grouping

## Documentation
- Update README to include:
  - OpenAI API in tech stack
  - Chat endpoint in API overview
  - Updated project structure
  - `OPENAI_API_KEY` setup

## Notes
- Backend-only change (no frontend integration yet)
- Endpoint verified via Postman with filtering, sorting, and edge cases