### PR TITLE
feat(chat): add frontend chatbot and unify filter normalization

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -10,7 +10,25 @@ import Register from "./pages/Register";
 import Login from "./pages/Login";
 import Profile from "./pages/Profile";
 import Watchlist from './pages/Watchlist';
+import WatchlistChat from './components/WatchlistChat';
 
+// Wrapper to protect pages needing logged in user
+function ProtectedRoute({ user, checkingAuth, children }) {
+  // While still checking /auth/profile on initial load, don't render anything yet
+  if (checkingAuth) {
+    return null;
+  }
+
+  // If there is no user after the check, redirect to /login
+  if (!user) {
+    return (
+      <Navigate to="/login" replace/>
+    );
+  }
+
+  // If user is authenticated, render the protected content
+  return children;
+}
 
 function AppShell() {
   const [results, setResults] = useState([]);   // stores results of search
@@ -88,24 +106,6 @@ function AppShell() {
     }
   }
 
-  // Wrapper to protect pages needing logged in user
-  function ProtectedRoute({ user, checkingAuth, children }) {
-    // While still checking /auth/profile on initial load, don't render anything yet
-    if (checkingAuth) {
-      return null;
-    }
-
-    // If there is no user after the check, redirect to /login
-    if (!user) {
-      return (
-        <Navigate to="/login" replace/>
-      );
-    }
-
-    // If user is authenticated, render the protected content
-    return children;
-  }
-
   return (
     <div className="flex flex-col min-h-screen bg-gray-200">
       
@@ -170,6 +170,7 @@ function AppShell() {
           {/* Protected watchlist page */}
           <Route path="/watchlist" element={<ProtectedRoute user={user} checkingAuth={checkingAuth}>
                                               <Watchlist watchlist={watchlist} setWatchlist={setWatchlist}/>
+                                              <WatchlistChat onResults={setWatchlist} />
                                             </ProtectedRoute>} />
         </Routes>
       </main>

--- a/client/src/components/WatchlistChat.jsx
+++ b/client/src/components/WatchlistChat.jsx
@@ -1,0 +1,131 @@
+import { useState } from 'react';
+import { sendWatchlistChatMessage } from '../services/chat';
+
+export default function WatchlistChat({ onResults }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [message, setMessage] = useState('');
+  const [chatLog, setChatLog] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+
+    const trimmedMessage = message.trim();
+    if (!trimmedMessage || isLoading) return;
+
+    setMessage('');
+    setIsLoading(true);
+
+    setChatLog((prev) => [
+      ...prev,
+      { role: 'user', text: trimmedMessage },
+    ]);
+
+    try {
+      const data = await sendWatchlistChatMessage(trimmedMessage);
+
+      onResults(data.items);
+
+      setChatLog((prev) => [
+        ...prev,
+        {
+          role: 'assistant',
+          text: buildSuccessMessage(data),
+        },
+      ]);
+    } catch (err) {
+      setChatLog((prev) => [
+        ...prev,
+        {
+          role: 'assistant',
+          text: err.message || 'Failed to process request',
+          isError: true,
+        },
+      ]);
+    } finally {
+      setIsLoading(false);
+      console.log(chatLog);
+    }
+  }
+
+  function buildSuccessMessage(data) {
+    const count = data.items?.length ?? 0;
+
+    if (count === 0) {
+      return 'No matching watchlist items found.';
+    }
+
+    if (data.action?.intent === 'sort_watchlist') {
+      return `Sorted ${count} watchlist item${count === 1 ? '' : 's'}.`;
+    }
+
+    return `Filters applied. Showing ${count} item${count === 1 ? '' : 's'}.`;
+  }
+
+  return (
+    <div className="fixed bottom-6 right-6 z-50 flex flex-col items-end gap-3">
+      {isOpen && (
+        <div className="w-80 rounded-2xl border border-slate-700 bg-slate-900/95 p-4 shadow-2xl">
+          <div className="mb-3">
+            <h3 className="text-sm font-semibold text-white">
+              Watchlist Assistant
+            </h3>
+            <p className="text-xs text-slate-400">
+              Try: “show my sci-fi movies after 2015”
+            </p>
+          </div>
+
+          <div className="mb-3 max-h-64 space-y-2 overflow-y-auto pr-1">
+            {chatLog.length === 0 ? (
+              <p className="text-sm text-slate-500">
+                Ask me to filter or sort your watchlist.
+              </p>
+            ) : (
+              chatLog.map((entry, index) => (
+                <div
+                  key={index}
+                  className={`rounded-xl px-3 py-2 text-sm ${
+                    entry.role === 'user'
+                      ? 'ml-8 bg-blue-600 text-white'
+                      : entry.isError
+                      ? 'mr-8 bg-red-900/70 text-red-100'
+                      : 'mr-8 bg-slate-800 text-slate-100'
+                  }`}
+                >
+                  {entry.text}
+                </div>
+              ))
+            )}
+          </div>
+
+          <form onSubmit={handleSubmit} className="flex gap-2">
+            <input
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              disabled={isLoading}
+              placeholder="Filter your watchlist..."
+              className="min-w-0 flex-1 rounded-xl border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white outline-none placeholder:text-slate-500 focus:border-blue-500"
+            />
+
+            <button
+              type="submit"
+              disabled={isLoading || message.trim() === ''}
+              className="rounded-xl bg-blue-600 px-3 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {isLoading ? '...' : 'Send'}
+            </button>
+          </form>
+        </div>
+      )}
+
+      <button
+        type="button"
+        onClick={() => setIsOpen((prev) => !prev)}
+        className="flex h-14 w-14 items-center justify-center rounded-full bg-blue-600 text-2xl text-white shadow-xl transition hover:bg-blue-500"
+        aria-label={isOpen ? 'Close watchlist assistant' : 'Open watchlist assistant'}
+      >
+        {isOpen ? '×' : '💬'}
+      </button>
+    </div>
+  );
+}

--- a/client/src/services/chat.js
+++ b/client/src/services/chat.js
@@ -1,0 +1,15 @@
+import { request } from './api';
+import { normalizeMovie } from '../utils/normalizeMovie';
+
+export async function sendWatchlistChatMessage(message) {
+    const data = await request('/chat/watchlist', {
+        method: 'POST',
+        body: JSON.stringify({ message }),
+        useGlobalLoading: true,
+    });
+
+    return {
+        ...data,
+        items: data.items.map(normalizeMovie),
+    };
+}

--- a/client/src/services/watchlist.js
+++ b/client/src/services/watchlist.js
@@ -1,46 +1,5 @@
 import { request } from "./api";
-
-function normalizeMovie(movie) {
-  // Build a Ratings array from raw strings
-  const ratings = [];
-  if (movie.imdbRaw) {
-    ratings.push({
-      Source: "Internet Movie Database",
-      Value: movie.imdbRaw,
-    });
-  }
-  if (movie.rtRaw) {
-    ratings.push({
-      Source: "Rotten Tomatoes",
-      Value: movie.rtRaw,
-    });
-  }
-  if (movie.mcRaw) {
-    ratings.push({
-      Source: "Metacritic",
-      Value: movie.mcRaw,
-    });
-  }
-
-  return {
-    imdbID: movie.imdbId,
-    Title: movie.title,
-    Poster: movie.poster,
-    Year: movie.year,
-    Type: movie.type,
-    Rated: movie.rated,
-    Genre: movie.genre,
-    Plot: movie.plot,
-    Director: movie.director,
-    Actors: movie.actors,
-
-    Ratings: ratings,
-    imdbScore: movie.imdbScore,
-    rtScore: movie.rtScore,
-    mcScore: movie.mcScore,
-    sortScore: movie.sortScore,
-  };
-}
+import { normalizeMovie } from "../utils/normalizeMovie"
 
 export async function fetchWatchlist() {
   const movies = await request("/watchlist", {

--- a/client/src/utils/normalizeMovie.js
+++ b/client/src/utils/normalizeMovie.js
@@ -1,0 +1,64 @@
+export function normalizeMovie(movie) {
+  // Build a Ratings array from raw strings
+  const ratings = [];
+  if (movie.imdbRaw) {
+    ratings.push({
+      Source: "Internet Movie Database",
+      Value: movie.imdbRaw,
+    });
+  }
+  if (movie.rtRaw) {
+    ratings.push({
+      Source: "Rotten Tomatoes",
+      Value: movie.rtRaw,
+    });
+  }
+  if (movie.mcRaw) {
+    ratings.push({
+      Source: "Metacritic",
+      Value: movie.mcRaw,
+    });
+  }
+
+  return {
+    // Identity
+    imdbID: movie.imdbId,
+
+    // Core metadata
+    Title: movie.title,
+    Type: movie.type,
+    Poster: movie.poster,
+    Rated: movie.rated,
+
+    // Raw OMDb fields
+    Year: movie.year,
+    Genre: movie.genre,
+    Runtime: movie.runtime,
+    Language: movie.language,
+    BoxOffice: movie.boxOffice,
+
+    // Parsed / query fields
+    releaseYear: movie.releaseYear,
+    genres: movie.genres,
+    runtimeMins: movie.runtimeMins,
+    languages: movie.languages,
+    boxOfficeValue: movie.boxOfficeValue,
+
+    // Descriptive metadata
+    Plot: movie.plot,
+    Director: movie.director,
+    Actors: movie.actors,
+
+    // Raw ratings reconstructed for existing UI
+    Ratings: ratings,
+
+    // Normalized ratings
+    imdbScore: movie.imdbScore,
+    rtScore: movie.rtScore,
+    mcScore: movie.mcScore,
+    sortScore: movie.sortScore,
+
+    // Timestamp
+    createdAt: movie.createdAt,
+  };
+}

--- a/server/routes/chat.routes.js
+++ b/server/routes/chat.routes.js
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import { prisma } from '../db.js';
 import { requireAuth } from '../middleware/requireAuth.js';
 import { parseWatchlistMessage } from '../services/chat.service.js';
-import { buildWatchlistQuery } from '../services/watchlistQuery.service.js';
+import { normalizeWatchlistFilters, buildWatchlistQuery } from '../services/watchlistQuery.service.js';
 import { serializeWatchlistItem } from '../utils/serializeWatchlistItem.util.js';
 
 const router = Router();
@@ -15,41 +15,47 @@ router.post('/watchlist', requireAuth, async (req, res) => {
       return res.status(400).json({ message: 'message is required' });
     }
 
+    // Send chat to OpenAI service
     const action = await parseWatchlistMessage(message.trim());
 
-    const normalizedGenre =
-      typeof action.genre === 'string' && action.genre.trim() !== ''
-        ? action.genre.trim().toLowerCase()
-        : null;
+    let rawFilters = {};
 
-    let filters = {};
-
-    if (action.intent === 'clear_filters') {
-      filters = {};
-    } else if (action.intent === 'sort_watchlist') {
-      filters = {
-        sortBy: action.sortBy ?? null,
-        order: action.order ?? null,
+    if (action.intent === 'sort_watchlist') {
+      rawFilters = {
+        sortBy: action.sortBy,
+        order: action.order,
       };
     } else if (action.intent === 'filter_watchlist') {
-      filters = {
-        type: action.type ?? null,
-        genre: normalizedGenre,
-        yearGte: action.yearGte ?? null,
-        yearLte: action.yearLte ?? null,
-        runtimeLte: action.runtimeLte ?? null,
-        sortBy: action.sortBy ?? null,
-        order: action.order ?? null,
+      rawFilters = {
+        type: action.type,
+        genre: action.genre,
+
+        yearGte: action.yearGte,
+        yearLte: action.yearLte,
+        runtimeLte: action.runtimeLte,
+
+        sortBy: action.sortBy,
+        order: action.order,
       };
     } else {
       return res.status(400).json({ message: 'Unsupported chat intent' });
     }
 
+    // Call watchlist service to normalize optional filters
+    let filters;
+    try {
+      filters = normalizeWatchlistFilters(rawFilters);
+    } catch (err) {
+      return res.status(400).json({ message: err.message });
+    }
+
+    // Call watchlist service to build Prisma *where* and *orderBy*
     const { where, orderBy } = buildWatchlistQuery({
       userId: req.userId,
       filters,
     });
 
+    // Query database
     const items = await prisma.watchlistItem.findMany({
       where,
       orderBy,

--- a/server/routes/watchlist.routes.js
+++ b/server/routes/watchlist.routes.js
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import { prisma } from '../db.js';
 import { requireAuth } from '../middleware/requireAuth.js';
 import { getMovieDetails } from '../services/omdb.service.js';
-import { buildWatchlistQuery } from '../services/watchlistQuery.service.js';
+import { normalizeWatchlistFilters, buildWatchlistQuery } from '../services/watchlistQuery.service.js';
 import { serializeWatchlistItem } from '../utils/serializeWatchlistItem.util.js';
 import { normalizeRatings } from '../utils/ratings.util.js';
 
@@ -11,121 +11,18 @@ const router = Router();
 // GET user watchlist
 router.get('/', requireAuth, async (req, res) => {
   try {
-    const { type, genre, sortBy, order, yearGte, yearLte, runtimeLte, } = req.query;
-
-    // --- Normalize values ---
-    let normalizedType = null;    // Optional type filter
-    if (typeof type === 'string' && type.trim() !== '') {
-      normalizedType = type.trim().toLowerCase();
-
-      const allowedTypes = new Set(['movie', 'series', 'game']);
-      if (!allowedTypes.has(normalizedType)) {
-        return res.status(400).json({ message: 'Invalid type filter' });
-      }
+    // Call watchlist service to normalize optional filters
+    let filters;
+    try {
+      filters = normalizeWatchlistFilters(req.query);
+    } catch (err) {
+      return res.status(400).json({ message: err.message });
     }
-
-    let normalizedGenre = null;   // Optional genre filter
-    if (typeof genre === 'string' && genre.trim() !== '') {
-      normalizedGenre = genre.trim().toLowerCase();
-    }
-
-    // Optional year > or < filter
-    const currentYear = new Date().getFullYear();
-
-    const parsedYearGte =
-      typeof yearGte === 'string' && yearGte.trim() !== ''
-        ? Number(yearGte)
-        : null;
-
-    if (parsedYearGte !== null) {
-      if (!Number.isInteger(parsedYearGte)) {
-        return res.status(400).json({ message: 'yearGte must be an integer' });
-      }
-
-      if (parsedYearGte < 1888 || parsedYearGte > currentYear + 10) {
-        return res.status(400).json({ message: 'yearGte is invalid' });
-      }
-    }
-
-    const parsedYearLte =
-      typeof yearLte === 'string' && yearLte.trim() !== ''
-        ? Number(yearLte)
-        : null;
-
-    if (parsedYearLte !== null) {
-      if (!Number.isInteger(parsedYearLte)) {
-        return res.status(400).json({ message: 'yearLte must be an integer' });
-      }
-
-      if (parsedYearLte < 1888 || parsedYearLte > currentYear + 10) {   // Date of first film
-        return res.status(400).json({ message: 'yearLte is invalid' });
-      }
-    }
-
-    if (parsedYearGte !== null && parsedYearLte !== null && parsedYearGte > parsedYearLte) {
-      return res.status(400).json({ message: 'yearGte cannot be greater than yearLte' });
-    }
-
-    // Optional runtime < filter
-    const parsedRuntimeLte =
-      typeof runtimeLte === 'string' && runtimeLte.trim() !== ''
-        ? Number(runtimeLte)
-        : null;
-
-    if (parsedRuntimeLte !== null) {
-      if (!Number.isInteger(parsedRuntimeLte)) {
-        return res.status(400).json({ message: 'runtimeLte must be an integer' });
-      }
-
-      if (parsedRuntimeLte <= 0) {
-        return res.status(400).json({ message: 'runtimeLte must be greater than 0' });
-      }
-    }
-
-    // Allowed sort fields
-    const allowedSortFields = new Set([
-      'createdAt',
-      'title',
-      'releaseYear',
-      'imdbScore',
-      'rtScore',
-      'mcScore',
-      'sortScore',
-    ]);
-
-    const sortField =
-      typeof sortBy === 'string' && allowedSortFields.has(sortBy)
-        ? sortBy
-        : 'createdAt';  // Default to *date added to watchlist*
-
-    // Fields with descending order by default
-    const defaultDescFields = new Set([
-      'createdAt',
-      'imdbScore',
-      'rtScore',
-      'mcScore',
-      'sortScore',
-    ]);
-
-    const sortOrder =
-      order === 'desc' || order === 'asc'
-        ? order
-        : defaultDescFields.has(sortField)
-        ? 'desc'
-        : 'asc';
 
     // Call watchlist service to build Prisma *where* and *orderBy*
     const { where, orderBy } = buildWatchlistQuery({
       userId: req.userId,
-      filters: {
-        type: normalizedType,
-        genre: normalizedGenre,
-        sortBy: sortField,
-        order: sortOrder,
-        yearGte: parsedYearGte,
-        yearLte: parsedYearLte,
-        runtimeLte: parsedRuntimeLte,
-      },
+      filters,
     });
     
     // Query database
@@ -134,9 +31,7 @@ router.get('/', requireAuth, async (req, res) => {
       orderBy,
     });
 
-    res.json(
-      items.map(serializeWatchlistItem)
-    );
+    res.json(items.map(serializeWatchlistItem));
   } catch (err) {
     console.error(err);
     res.status(500).json({ message: 'Failed to load watchlist' });

--- a/server/services/watchlistQuery.service.js
+++ b/server/services/watchlistQuery.service.js
@@ -1,13 +1,130 @@
+export function normalizeWatchlistFilters(filters = {}) {
+	const { type, genre, yearGte, yearLte, runtimeLte, sortBy, order } = filters;
+
+    // Optional type filter
+    let normalizedType = null;
+    if (typeof type === 'string' && type.trim() !== '') {
+      normalizedType = type.trim().toLowerCase();
+
+      const allowedTypes = new Set(['movie', 'series', 'game']);
+      if (!allowedTypes.has(normalizedType)) {
+        throw new Error('Invalid type filter');
+      }
+    }
+
+	// Optional genre filter
+    let normalizedGenre = null;
+    if (typeof genre === 'string' && genre.trim() !== '') {
+      normalizedGenre = genre.trim().toLowerCase();
+    }
+
+	// Optional year > or < filter
+    const currentYear = new Date().getFullYear();
+
+    const parsedYearGte =
+      typeof yearGte === 'string' && yearGte.trim() !== ''
+        ? Number(yearGte)
+		: typeof yearGte === 'number'
+    	? yearGte
+        : null;
+
+    if (parsedYearGte !== null) {
+      if (!Number.isInteger(parsedYearGte)) {
+        throw new Error('yearGte must be an integer');
+      }
+
+      if (parsedYearGte < 1888 || parsedYearGte > currentYear + 10) {   // Date of first film
+        throw new Error('yearGte is invalid');
+      }
+    }
+
+    const parsedYearLte =
+      typeof yearLte === 'string' && yearLte.trim() !== ''
+        ? Number(yearLte)
+		: typeof yearLte === 'number'
+    	? yearLte
+        : null;
+
+    if (parsedYearLte !== null) {
+      if (!Number.isInteger(parsedYearLte)) {
+        throw new Error('yearLte must be an integer');
+      }
+
+      if (parsedYearLte < 1888 || parsedYearLte > currentYear + 10) {   // Date of first film
+        throw new Error('yearLte is invalid');
+      }
+    }
+
+    if (parsedYearGte !== null && parsedYearLte !== null && parsedYearGte > parsedYearLte) {
+      throw new Error('yearGte cannot be greater than yearLte');
+    }
+
+	// Optional runtime < filter
+    const parsedRuntimeLte =
+      typeof runtimeLte === 'string' && runtimeLte.trim() !== ''
+        ? Number(runtimeLte)
+		: typeof runtimeLte === 'number'
+    	? runtimeLte
+        : null;
+
+    if (parsedRuntimeLte !== null) {
+      if (!Number.isInteger(parsedRuntimeLte)) {
+        throw new Error('runtimeLte must be an integer');
+      }
+
+      if (parsedRuntimeLte <= 0) {
+        throw new Error('runtimeLte must be greater than 0');
+      }
+    }
+
+	// Allowed sort fields
+    const allowedSortFields = new Set([
+      'createdAt',
+      'title',
+      'releaseYear',
+	  'runtimeMins',
+      'imdbScore',
+      'rtScore',
+      'mcScore',
+      'sortScore',
+    ]);
+
+    const sortField =
+      typeof sortBy === 'string' && allowedSortFields.has(sortBy)
+        ? sortBy
+        : 'createdAt';  // Default to *date added to watchlist*
+
+    // Fields with descending order by default
+    const defaultDescFields = new Set([
+      'createdAt',
+      'imdbScore',
+      'rtScore',
+      'mcScore',
+      'sortScore',
+    ]);
+
+    const sortOrder =
+      order === 'desc' || order === 'asc'
+        ? order
+        : defaultDescFields.has(sortField)
+        ? 'desc'
+        : 'asc';
+
+	return {
+        type: normalizedType,
+        genre: normalizedGenre,
+
+        yearGte: parsedYearGte,
+        yearLte: parsedYearLte,
+        runtimeLte: parsedRuntimeLte,
+
+		sortBy: sortField,
+		order: sortOrder,
+    };
+}
+
 export function buildWatchlistQuery({ userId, filters }) {
-	const {
-		type,
-		genre,
-		sortBy,
-		order,
-		yearGte,
-		yearLte,
-		runtimeLte,
-	} = filters;
+	const { type, genre, yearGte, yearLte, runtimeLte, sortBy, order } = filters;
 
 	const where = { userId };
 
@@ -25,38 +142,7 @@ export function buildWatchlistQuery({ userId, filters }) {
 
 	if (runtimeLte != null) where.runtimeMins = { lte: runtimeLte };    // runtime
 
-	// --- Sorting ---
-	const allowedSortFields = new Set([
-		'createdAt',
-		'title',
-		'releaseYear',
-		'runtimeMins',
-		'imdbScore',
-		'rtScore',
-		'mcScore',
-		'sortScore',
-	]);
-
-	const sortField = allowedSortFields.has(sortBy)
-		? sortBy
-		: 'createdAt';
-
-	const defaultDescFields = new Set([
-		'imdbScore',
-		'rtScore',
-		'mcScore',
-		'sortScore',
-		'createdAt',
-	]);
-
-	const sortOrder =
-		order === 'desc' || order === 'asc'
-			? order
-			: defaultDescFields.has(sortField)
-			? 'desc'
-			: 'asc';
-
-	const orderBy = { [sortField]: sortOrder };
+	const orderBy = { [sortBy]: order };
 
 	return { where, orderBy };
 }


### PR DESCRIPTION
- move ProtectedRoute out of AppShell to prevent component remounting
- add chat service for /api/chat/watchlist integration
- add WatchlistChat component with floating UI and chat history
- move normalizeMovie to frontend utils for reuse across services

- refactor backend filter handling:
  - move normalizeWatchlistFilters into watchlistQuery.service
  - reuse normalization in both watchlist GET and chat routes

enables persistent chat UI and consistent filtering across API endpoints